### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # v4
       with:
         python-version: "3.x"
 
@@ -26,7 +26,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3
       with:
         name: python-package-distributions
         path: dist/
@@ -46,12 +46,12 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3
       with:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1
 
   publish-to-testpypi:
     name: Publish Python distribution to TestPyPI
@@ -68,11 +68,11 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a  # v3
       with:
         name: python-package-distributions
         path: dist/
     - name: Publish distribution to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1
       with:
         repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,9 +21,9 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Set up Python 3.8
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
       with:
         python-version: 3.8
         cache: pip
@@ -32,7 +32,7 @@ jobs:
       env:
         SKIP: "no-commit-to-branch,mypy"
 
-      uses: pre-commit/action@v3.0.1
+      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
 #       # mypy turned off for now
 #    - name: Lint with mypy
 #      run: mypy . --ignore-missing-imports --check-untyped-defs --explicit-package-bases --warn-unreachable
@@ -46,9 +46,9 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
@@ -63,7 +63,7 @@ jobs:
     - name: Test with pytest
       run: python -m pytest --showlocals -s -vv -n=auto --ignore=tests/models/test_neuralmagic.py --ignore=tests/models/test_openvino.py
     - name: Archive artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3
       with:
         name: output_results
         path: |
@@ -74,9 +74,9 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
       with:
         python-version: 3.11
         cache: pip
@@ -88,7 +88,7 @@ jobs:
     - name: Test with pytest
       run: python -m pytest tests/models --showlocals -s -vv
     - name: Archive artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5  # v3
       with:
         name: output_results
         path: |


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `unit_tests.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `unit_tests.yml` | `actions/setup-python` | `v5` | `v5` | `a26af69be951…` |
| `unit_tests.yml` | `pre-commit/action` | `v3.0.1` | `v3.0.1` | `2c7b3805fd2a…` |
| `unit_tests.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `unit_tests.yml` | `actions/setup-python` | `v5` | `v5` | `a26af69be951…` |
| `unit_tests.yml` | `actions/upload-artifact` | `v3` | `v3` | `ff15f0306b3f…` |
| `unit_tests.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `unit_tests.yml` | `actions/setup-python` | `v5` | `v5` | `a26af69be951…` |
| `unit_tests.yml` | `actions/upload-artifact` | `v3` | `v3` | `ff15f0306b3f…` |
| `publish.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `publish.yml` | `actions/setup-python` | `v4` | `v4` | `7f4fc3e22c37…` |
| `publish.yml` | `actions/upload-artifact` | `v3` | `v3` | `ff15f0306b3f…` |
| `publish.yml` | `actions/download-artifact` | `v3` | `v3` | `9bc31d5ccc31…` |
| `publish.yml` | `pypa/gh-action-pypi-publish` | `release/v1` | `release/v1` | `ed0c53931b1d…` |
| `publish.yml` | `actions/download-artifact` | `v3` | `v3` | `9bc31d5ccc31…` |
| `publish.yml` | `pypa/gh-action-pypi-publish` | `release/v1` | `release/v1` | `ed0c53931b1d…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#171